### PR TITLE
MSVC support

### DIFF
--- a/lmdb++.h
+++ b/lmdb++.h
@@ -1064,7 +1064,7 @@ public:
   }
 };
 
-#ifndef __COVERITY__
+#if !defined(__COVERITY__) || !defined(_MSC_VER)
 static_assert(std::is_pod<lmdb::val>::value, "lmdb::val must be a POD type");
 static_assert(sizeof(lmdb::val) == sizeof(MDB_val), "sizeof(lmdb::val) != sizeof(MDB_val)");
 #endif

--- a/lmdb++.h
+++ b/lmdb++.h
@@ -1064,7 +1064,7 @@ public:
   }
 };
 
-#if !defined(__COVERITY__) || !defined(_MSC_VER)
+#if !(defined(__COVERITY__) || defined(_MSC_VER))
 static_assert(std::is_pod<lmdb::val>::value, "lmdb::val must be a POD type");
 static_assert(sizeof(lmdb::val) == sizeof(MDB_val), "sizeof(lmdb::val) != sizeof(MDB_val)");
 #endif

--- a/lmdb++.h
+++ b/lmdb++.h
@@ -15,7 +15,9 @@
 #endif
 
 #if __cplusplus < 201103L
+#if !defined(_MSC_VER) || _MSC_VER < 1900
 #error "<lmdb++.h> requires a C++11 compiler (CXXFLAGS='-std=c++11')"
+#endif // _MSC_VER check
 #endif
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Hello,

while trying to compile on windows I ran into a few minor issues.

Mainly because [Microsoft has not updated `__cplusplus` for *years*](https://connect.microsoft.com/VisualStudio/feedback/details/763051/a-value-of-predefined-macro-cplusplus-is-still-199711l).

For some odd reason it does not think `lmdb::val` is a POD. Given the info on [PODTypes on CppReference](http://en.cppreference.com/w/cpp/concept/PODType) I'd guess it's still doing pre-11 checks or the default-declared dtor confuses him.

My testings were done with VS2015, which afaik is fully compliant with c++11.