### PR TITLE
Modify cursor_put so it matches dbi_put.

### DIFF
--- a/lmdb++.h
+++ b/lmdb++.h
@@ -810,7 +810,7 @@ namespace lmdb {
   static inline MDB_txn* cursor_txn(MDB_cursor* cursor) noexcept;
   static inline MDB_dbi cursor_dbi(MDB_cursor* cursor) noexcept;
   static inline bool cursor_get(MDB_cursor* cursor, MDB_val* key, MDB_val* data, MDB_cursor_op op);
-  static inline void cursor_put(MDB_cursor* cursor, MDB_val* key, MDB_val* data, unsigned int flags);
+  static inline bool cursor_put(MDB_cursor* cursor, MDB_val* key, MDB_val* data, unsigned int flags);
   static inline void cursor_del(MDB_cursor* cursor, unsigned int flags);
   static inline void cursor_count(MDB_cursor* cursor, std::size_t& count);
 }
@@ -886,15 +886,16 @@ lmdb::cursor_get(MDB_cursor* const cursor,
  * @throws lmdb::error on failure
  * @see http://symas.com/mdb/doc/group__mdb.html#ga1f83ccb40011837ff37cc32be01ad91e
  */
-static inline void
+static inline bool
 lmdb::cursor_put(MDB_cursor* const cursor,
                  MDB_val* const key,
                  MDB_val* const data,
                  const unsigned int flags = 0) {
   const int rc = ::mdb_cursor_put(cursor, key, data, flags);
-  if (rc != MDB_SUCCESS) {
+  if (rc != MDB_SUCCESS && rc != MDB_KEYEXIST) {
     error::raise("mdb_cursor_put", rc);
   }
+  return (rc == MDB_SUCCESS);
 }
 
 /**


### PR DESCRIPTION
dbi_put return false if it cannot insert a duplicate
value because of MDB_NODUPDATA or MDB_NOOVERWRITE,
while cursor_put will raise an exception.

This patch modifies cursor_put so it has the same
behavior as dbi_put.
