### PR TITLE
Nontemplate version of key-only dbi::get()

### DIFF
--- a/lmdb++.h
+++ b/lmdb++.h
@@ -1534,6 +1534,19 @@ public:
    * @param key
    * @throws lmdb::error on failure
    */
+  bool get(MDB_txn* const txn,
+           const val& key) const {
+    lmdb::val v{};
+    return lmdb::dbi_get(txn, handle(), key, v);
+  }
+
+  /**
+   * Retrieves a key from this database.
+   *
+   * @param txn a transaction handle
+   * @param key
+   * @throws lmdb::error on failure
+   */
   template<typename K>
   bool get(MDB_txn* const txn,
            const K& key) const {

--- a/lmdb++.h
+++ b/lmdb++.h
@@ -1894,6 +1894,16 @@ public:
   }
 
   /**
+   * Removes current key/value pair from this database.
+   *
+   * @param flags Allows MDB_NODUPDATA if the database was opened with MDB_DUPSORT
+   * @throws lmdb::error on failure
+   */
+  void del(const unsigned int flags = 0) {
+    lmdb::cursor_del(handle(), flags);
+  }
+
+  /**
    * Positions this cursor at the given key.
    *
    * @param key


### PR DESCRIPTION
The templated version of key-only dbi::get() doesn't work with lmdb::val keys, since it packs the raw binar lmdb::val data into a second lmdb::val.

The current template methods are only safe with native C non-pointer data types.
