### PR TITLE
Update lmdb++.h

### DIFF
--- a/lmdb++.h
+++ b/lmdb++.h
@@ -1194,6 +1194,11 @@ public:
   env& open(const char* const path,
             const unsigned int flags = default_flags,
             const mode mode = default_mode) {
+#if defined(_MSC_VER)
+#if defined(_WIN32)
+	CreateDirectory(path, NULL);
+#endif
+#endif
     lmdb::env_open(handle(), path, flags, mode);
     return *this;
   }


### PR DESCRIPTION
DB folder was not created, while opening DB in windows.
env.open(DB_name.c_str()); in example program exited after this line with code 3.
