### PR TITLE
add const to lmdb::dbi::get (for consistency)

### DIFF
--- a/lmdb++.h
+++ b/lmdb++.h
@@ -1523,7 +1523,7 @@ public:
    */
   bool get(MDB_txn* const txn,
            const val& key,
-           val& data) {
+           val& data) const {
     return lmdb::dbi_get(txn, handle(), key, data);
   }
 


### PR DESCRIPTION
This simple change adds `const` qualifier to one `lmdb::dbi::last` overload to be consistent with other ones. I think this was simply a typo and that there is no reason to keep the method non-const. The current state creates some confusion when the overloads are being resolved.